### PR TITLE
Replace 'Package' with ensure_packages

### DIFF
--- a/manifests/repo/gogs_apt.pp
+++ b/manifests/repo/gogs_apt.pp
@@ -4,7 +4,7 @@ class gogs::repo::gogs_apt(
 
   include ::apt
 
-  package { 'apt-transport-https': }
+  ensure_packages('apt-transport-https')
 
   apt::source { 'deb.packager.io-gogs':
     comment     => 'This is the Gogs package repository on packager.io',


### PR DESCRIPTION
To avoid conflicts with docker module:

```
==> default: Error: Evaluation Error: Error while evaluating a Function Call, Duplicate
 declaration: Package[apt-transport-https] is already declared in file 
/etc/puppetlabs/code/environments/production/modules/gogs/manifests
/repo/gogs_apt.pp:7; cannot redeclare at /etc/puppetlabs/code/environments
/production/modules/docker/manifests/repos.pp:12:7 on node myprecise.box
```