### PR TITLE
Resource ordering

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -35,7 +35,9 @@ class gogs::config(
 ) inherits gogs::params {
 
   user { $owner:
-    ensure  => present,
+    ensure     => present,
+    managehome => true,
+    require    => Group[$group],
   }
 
   group { $group:
@@ -43,9 +45,10 @@ class gogs::config(
   }
 
   file { $repository_root:
-    ensure => 'directory',
-    owner  => $owner,
-    group  => $group,
+    ensure  => 'directory',
+    owner   => $owner,
+    group   => $group,
+    require => User[$owner]
   }
 
   file { '/etc/gogs/conf/app.ini':
@@ -53,6 +56,7 @@ class gogs::config(
     content => template('gogs/app.ini.erb'),
     owner   => $owner,
     group   => $group,
+    require => Package['gogs']
   }
 
   file { '/etc/init.d/gogs':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -115,11 +115,9 @@ class gogs (
   # Parameter validation
   validate_bool($install_repo)
 
-  anchor { 'gogs::begin': } ->
-  class  { '::gogs::repo': } ->
-  class  { '::gogs::install': } ->
-  class  { '::gogs::config': } ~>
-  class  { '::gogs::service': } ->
-  anchor { 'gogs::end': }
+  include ::gogs::repo
+  include ::gogs::install
+  include ::gogs::config
+  include ::gogs::service
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,7 +8,7 @@ class gogs::install(
 ) {
 
   package { 'gogs':
-    name   => $package_name,
     ensure => $package_ensure,
+    name   => $package_name,
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,7 +7,8 @@ class gogs::install(
 
 ) {
 
-  package { $package_name:
+  package { 'gogs':
+    name   => $package_name,
     ensure => $package_ensure,
   }
 }

--- a/manifests/repo/gogs_apt.pp
+++ b/manifests/repo/gogs_apt.pp
@@ -18,12 +18,7 @@ class gogs::repo::gogs_apt(
     include_src => false,
     require     => [
       Package['apt-transport-https']
-    ]
+    ],
+    before      => Package['gogs']
   }
-
-  # Make sure repo is configured before package is installed
-  Apt::Source['deb.packager.io-gogs'] -> Package<|
-    tag == 'gogs'
-    and title != 'apt-transport-https'
-  |>
 }

--- a/manifests/repo/gogs_apt.pp
+++ b/manifests/repo/gogs_apt.pp
@@ -1,6 +1,5 @@
 # PRIVATE CLASS: do not use directly
-class gogs::repo::gogs_apt(
-) inherits gogs::repo {
+class gogs::repo::gogs_apt {
 
   include ::apt
 
@@ -16,9 +15,7 @@ class gogs::repo::gogs_apt(
         source => 'https://deb.packager.io/key',
     },
     include_src => false,
-    require     => [
-      Package['apt-transport-https']
-    ],
+    require     => Package['apt-transport-https'],
     before      => Package['gogs']
   }
 }

--- a/manifests/repo/gogs_yum.pp
+++ b/manifests/repo/gogs_yum.pp
@@ -1,6 +1,5 @@
 # PRIVATE CLASS: do not use directly
-class gogs::repo::gogs_yum(
-) inherits gogs::repo {
+class gogs::repo::gogs_yum {
 
   yumrepo { 'rpm.packager.io-gogs':
     descr    => 'Gogs yum repo on Packager.io',

--- a/manifests/repo/gogs_yum.pp
+++ b/manifests/repo/gogs_yum.pp
@@ -8,8 +8,6 @@ class gogs::repo::gogs_yum(
     enabled  => 1,
     gpgcheck => 1,
     gpgkey   => 'https://rpm.packager.io/key',
+    before   => Package['gogs'],
   }
-
-  # Ensure the repository is configured before package is installed
-  Yumrepo['rpm.packager.io-gogs'] -> Package<|tag == 'gogs'|>
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -13,5 +13,6 @@ class gogs::service
     ensure     => $service_ensure,
     hasrestart => true,
     enable     => true,
+    require    => Package['gogs']
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -13,6 +13,7 @@ class gogs::service
     ensure     => $service_ensure,
     hasrestart => true,
     enable     => true,
-    require    => Package['gogs']
+    require    => Package['gogs'],
+    subscribe  => File['/etc/gogs/conf/app.ini'],
   }
 }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -17,8 +17,9 @@ describe 'gogs::install', :type => :class do
             :lsbdistcodename => 'trusty'
           }
         end
-        it { is_expected.to contain_package('g0gz')
+        it { is_expected.to contain_package('gogs')
                .with_ensure('1.2.3.4')
+               .with_name('g0gz')
            }
       end
     end


### PR DESCRIPTION
-Moves the ordering to the resource level instead of the class level.
-Uses the resource title 'gogs' for the package declaration and uses the name parameter to support different package names in RedHat and Debian.
-Removes anchor pattern and chaining arrows to allow the compiler have more control of resource ordering.
-Makes some dependencies explicit rather than relying on manifest order.

This doesn't really belong in the PR, but it's a tiny change:
-Manages the 'gogs' user's home directory since that a dependency.
