### PR TITLE
Remove the unicode characters

### DIFF
--- a/templates/app.ini.erb
+++ b/templates/app.ini.erb
@@ -250,5 +250,5 @@ INTERVAL = 24
 ARGS =
 
 [i18n]
-LANGS = en-US,zh-CN,zh-HK,de-DE,fr-FR,nl-NL,lv-LV
-NAMES = English,简体中文,繁體中文,Deutsch,Français,Nederlands,Latviešu
+LANGS = en-US
+NAMES = English


### PR DESCRIPTION
This is to help anyone else that runs into a problem like I did.

We have puppetdb running in postgres. We haven't dug through and found a true root-cause, but we think that the encoding is being treated improperly, causing failures when replacing the catalog in the db.

We hit the following error in any template containing a unicode character, like in the i18n section of the `app.ini.erb` within this repository:

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed to submit 'replace catalog' command for test-puppet.internal to PuppetDB at puppet-master:8081: [500 java.util.concurrent.TimeoutException: Idle timeout expired: 30000/30000 ms] <html><head><meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/><title>Error 500 </title></head><body><h2>HTTP ERROR: 500</h2><p>Problem accessing /v3/commands. Reason:<pre>    java.util.concurrent.TimeoutException: Idle timeout expired: 30000/30000 ms</pre></p><hr /><i><small>Powered by Jetty://</small></i></body></html>
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```

As you can see, the error doesn't really give much information, but I have confirmed that the combination of the template and unicode characters is causing the error to appear.

If we can find a true root-cause, we'll submit a ticket to puppet. If anyone else has a similar issue, the fix is just to remove the unicode characters from the one template in this module.