### PR TITLE
Remove the service and the conf files of the RPM

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,5 +9,16 @@ class gogs::install(
 
   package { $package_name:
     ensure => $package_ensure,
+  } ->
+  # The following service is installed through the rpm and must be stopped first
+  exec { 'Stopping_gogs_via_initctl' : 
+    command => 'initctl stop gogs',
+    cwd    => '/etc/init',
+    path   => ['/sbin', '/usr/bin'],
+    onlyif => ['test -f /etc/init/gogs.conf', 'test -f /etc/init/gogs-web-1.conf', 'test -f /etc/init/gogs-web.conf'],
+  } ->
+  # The following files are installed through the rpm and must be removed
+  file { ['/etc/init/gogs.conf', '/etc/init/gogs-web-1.conf', '/etc/init/gogs-web.conf']:
+    ensure => absent,
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,11 +11,11 @@ class gogs::install(
     ensure => $package_ensure,
   } ->
   # The following service is installed through the rpm and must be stopped first
-  exec { 'Stopping_gogs_via_initctl' : 
+  exec { 'Stopping_gogs_via_initctl':
     command => 'initctl stop gogs',
-    cwd    => '/etc/init',
-    path   => ['/sbin', '/usr/bin'],
-    onlyif => ['test -f /etc/init/gogs.conf', 'test -f /etc/init/gogs-web-1.conf', 'test -f /etc/init/gogs-web.conf'],
+    cwd     => '/etc/init',
+    path    => ['/sbin', '/usr/bin'],
+    onlyif  => ['test -f /etc/init/gogs.conf', 'test -f /etc/init/gogs-web-1.conf', 'test -f /etc/init/gogs-web.conf'],
   } ->
   # The following files are installed through the rpm and must be removed
   file { ['/etc/init/gogs.conf', '/etc/init/gogs-web-1.conf', '/etc/init/gogs-web.conf']:


### PR DESCRIPTION
We need to stop and remove the gogs service and the conf file that come
with the RPM. Otherwise, the module will not work. See
https://github.com/Siteminds/puppet-gogs/issues/28